### PR TITLE
feat: 允许拖动窗口 fix: 读图页面直接关闭时保存进度

### DIFF
--- a/src/components/Header/index.vue
+++ b/src/components/Header/index.vue
@@ -57,6 +57,7 @@ export default {
   right: 5px;
   height: 30px;
   z-index: 100;
+  -webkit-app-region: drag;
   .back {
     float: left;
     width: 34px;
@@ -66,6 +67,7 @@ export default {
     text-align: center;
     color: #eee;
     cursor: pointer;
+    -webkit-app-region: no-drag;
     &:hover {
       background-color: #888;
     }
@@ -81,6 +83,7 @@ export default {
       text-align: center;
       color: #eee;
       cursor: pointer;
+      -webkit-app-region: no-drag;
       &:hover {
         background-color: #888;
       }

--- a/src/views/Comic/index.vue
+++ b/src/views/Comic/index.vue
@@ -122,14 +122,7 @@ export default {
     window.addEventListener('wheel', this.handleScroll, false)
   },
   beforeDestroy() {
-    const comicList = this.list[this.curInx] ? this.list[this.curInx].comicList : []
-    const comic = comicList.find(o => o.filename === this.filename)
-    if (comic) {
-      comic.progress = this.inx
-      const list = [...this.list]
-      this.$emit('setList', list)
-    }
-
+    this.saveProgress();
     window.removeEventListener('keydown', this.keydown)
     window.removeEventListener('wheel', this.handleScroll)
   },
@@ -229,6 +222,7 @@ export default {
       if (oldInx !== this.inx) {
         this.$refs.comic.scrollTop = 0
       }
+      this.saveProgress();
     },
     // 切换模式
     switchAdapt() {
@@ -240,6 +234,16 @@ export default {
       this.page = this.page === 1 ? 2 : 1
       this.setPageFile()
       this.$dataStore.set('page', this.page)
+    },
+    //保存进度
+    saveProgress(){
+      const comicList = this.list[this.curInx] ? this.list[this.curInx].comicList : []
+      const comic = comicList.find(o => o.filename === this.filename)
+      if (comic) {
+        comic.progress = this.inx
+        const list = [...this.list]
+        this.$emit('setList', list)
+      }
     }
   }
 }


### PR DESCRIPTION
允许用户拖动窗口，例如多显示器情况下。
在读图页面关闭应用时，保存进度。